### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ This additional panel field for [Kirby 2](http://getkirby.com) allows you to use
 
 ## Installation
 
-Copy or link the `wysiwyg` directory to `site/plugins/` **or** use the [Kirby CLI](https://github.com/getkirby/cli) `kirby plugin:install storypioneers/kirby-wysiwyg`.
+1.Download kirby-wysiwyg project as ZIP from github
+2.Create /site/fields folder if it doesn't exist
+3.Extract kirby-wysiwyg and copy 'fields' folder to /site/fields
+4.Rename /site/fields/field to /site/fields/wysiwyg
+
+**or** use the [Kirby CLI](https://github.com/getkirby/cli) `kirby plugin:install storypioneers/kirby-wysiwyg`.
 
 
 *Optional: Set some configuration options for Kirby WYSIWYG Editor in your sites `config.php` file. You can get an overview of all available options further down.*


### PR DESCRIPTION
Original installation instructions are not working.. "Copy or link the wysiwyg directory to site/plugins/" is not doing anything. Also default kirby installation doesn't have fields directory in /site folder. @nyash suggested easy 4 steps in issues and it worked for me on latest kirby version.

https://github.com/storypioneers/kirby-wysiwyg/issues/36#issuecomment-249548152
